### PR TITLE
List clusters via optional flag

### DIFF
--- a/bin/esvm.js
+++ b/bin/esvm.js
@@ -104,7 +104,7 @@ if (commander.clusterName) {
 // If given the list command and a config file, list clusters and exit
 if (commander.config && commander.list) {
   console.log(formatter(config.clusters))
-  process.exit();
+  return;
 }
 
 options.config = options.config;

--- a/bin/esvm.js
+++ b/bin/esvm.js
@@ -13,6 +13,7 @@ var join        = require('path').join;
 var flattenWith = require('../lib/flattenWith');
 var explodeBy   = require('../lib/explodeBy');
 var mergeConfig = require('../lib/mergeConfig');
+var formatter   = require('../lib/formatClusters');
 
 var rcloader = new RcLoader('.esvmrc');
 var config = rcloader.for('.esvmrc');
@@ -34,11 +35,13 @@ commander
 	.option('-b, --branch', 'install from a branch release')
 	.option('-n, --nodes <n>', 'the number of nodes to start', parseInt)
 	.option('-c, --config <file>', 'the config file to use')
+	.option('-l, --list', 'list clusters in the config file')
 	.option('--cluster-name <name>', 'the cluster name to use')
 	.parse(process.argv);
 
 var version = commander.args[0];
 var options = {};
+
 
 // If a config is passed via command line use that instead of the rcfile
 if (commander.config) {
@@ -98,6 +101,11 @@ if (commander.clusterName) {
   options.clusterNameOverride = commander.clusterName;
 }
 
+// If given the list command and a config file, list clusters and exit
+if (commander.config && commander.list) {
+  console.log(formatter(config.clusters))
+  process.exit();
+}
 
 options.config = options.config;
 var cluster = libesvm.createCluster(options);

--- a/lib/formatClusters.js
+++ b/lib/formatClusters.js
@@ -1,0 +1,29 @@
+var Table = require('cli-table');
+
+module.exports = function (clusters) {
+  var table = new Table({
+    head: ['Cluster Name', 'Version', 'Plugins']
+  });
+
+  var clusterNames = Object.keys(clusters);
+  clusterNames.forEach(function (clusterName) {
+    var cluster = clusters[clusterName];
+
+    // append cluster name
+    var output = [clusterName];
+
+    // append branch/version
+    if (cluster.branch) output.push(cluster.branch + ' branch');
+    else if (cluster.version) output.push('v' + cluster.version);
+    else output.push('n/a');
+
+    // append plugins
+    if (cluster.plugins) output.push(cluster.plugins.join(','));
+    else output.push('');
+
+    // append cluster row to table
+    return table.push(output);
+  });
+
+  return table.toString();
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "cli-color": "^0.3.2",
+    "cli-table": "^0.3.1",
     "commander": "^2.3.0",
     "libesvm": "^3.2.0",
     "lodash": "^2.4.1",


### PR DESCRIPTION
Adds the ability to list the clusters in a config file, as well as important metadata, using the `-l/--list` command.

Closes #22 

```
  Options:

    [...snip...]
    -l, --list             list clusters in the config file
```

![screenshot 2015-12-14 19 05 46](https://cloud.githubusercontent.com/assets/404731/11799995/bc80e73e-a295-11e5-9093-41d7f120eb7e.png)
