### PR TITLE
format plugin column values to show path/staging setup

### DIFF
--- a/lib/formatClusters.js
+++ b/lib/formatClusters.js
@@ -17,8 +17,20 @@ module.exports = function (clusters) {
     else if (cluster.version) output.push('v' + cluster.version);
     else output.push('n/a');
 
+    var plugins = [];
+
     // append plugins
-    if (cluster.plugins) output.push(cluster.plugins.join(','));
+    if (cluster.plugins) {
+      cluster.plugins.forEach(function (plugin) {
+        if (Object.prototype.toString.call(plugin) == '[object Object]') {
+          var descriptor = plugin.staging ? 'staging' : plugin.path;
+          plugins.push(plugin.name + ' - ' + descriptor);
+        } else {
+          plugins.push(plugin);
+        }
+      });
+      output.push(plugins.join('\n'));
+    }
     else output.push('');
 
     // append cluster row to table


### PR DESCRIPTION
If we have a esvm setup where plugins are specified by object, and use the `-l` option, it looks like this:

![image](https://cloud.githubusercontent.com/assets/908371/12465448/53b9981e-bf8b-11e5-87c8-85eb7b848598.png)

This changes the format so the objects fields are used, and it separates the plugins by newline:

![image](https://cloud.githubusercontent.com/assets/908371/12465434/328b03c6-bf8b-11e5-90fd-0266fea1bbed.png)

